### PR TITLE
Update nerd-icons.el version to match current

### DIFF
--- a/nerd-icons-completion.el
+++ b/nerd-icons-completion.el
@@ -5,7 +5,7 @@
 ;; Author: Hongyu Ding <rainstormstudio@yahoo.com>
 ;; Keywords: lisp
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "25.1") (nerd-icons "0.0.1") (compat "30"))
+;; Package-Requires: ((emacs "25.1") (nerd-icons "0.1.0") (compat "30"))
 ;; URL: https://github.com/rainstormstudio/nerd-icons-completion
 ;; Keywords: convenient, files, icons
 


### PR DESCRIPTION
`nerd-icons.el`  has updated its version to 0.1.0. Now installing the `nerd-icons-completions` package fails in `Spacemacs`, because the dependent version of `nerd-icons.el` doesn't match anymore.